### PR TITLE
feat: NIP-46 remote signing support (bunker mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.2.0] - 2026-02-13
+
+### Added
+
+- **NIP-46 Remote Signing Support** (Closes #5)
+  - `--bunker` flag and `NOSTR_BUNKER` env var for bunker:// URI
+  - `init --bunker` command for first-time bunker setup
+  - `migrate-to-bunker` command for atomic nsec → bunker migration
+  - `signer-status` command to inspect signing mode and connection info
+  - Bunker connection config persisted in `marmot.bunker.json` (auto-reconnect)
+  - Client keypair generated and stored for stable NIP-46 sessions
+  - All signing operations (events, gift-wrap, NIP-44 encryption) routed through bunker
+  - Audit logging of all signing requests to `marmot.audit.jsonl`
+  - Graceful bunker-offline handling with clear error messages
+  - Backward compatible: `--nsec` / `NOSTR_NSEC` still works as before
+
+### Changed
+
+- `whoami` now shows signing mode (direct/bunker)
+- `nostr-connect` v0.44.0 added as dependency
+- Signer abstraction (`MarmotSigner`) unifies direct and remote signing
+- Warning emitted when using direct nsec in long-running processes
+
 ## [Unreleased] - 2026-02-11
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +345,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +426,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-models"
@@ -660,6 +689,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -1033,6 +1068,30 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1486,6 +1545,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,21 +1579,25 @@ checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 
 [[package]]
 name = "marmot-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "hex",
  "mdk-core",
  "mdk-sqlite-storage",
  "mdk-storage-traits",
  "nostr",
+ "nostr-connect",
  "nostr-sdk",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -1654,6 +1723,7 @@ version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
 dependencies = [
+ "aes",
  "base64",
  "bech32",
  "bip39",
@@ -1670,6 +1740,19 @@ dependencies = [
  "serde_json",
  "unicode-normalization",
  "url",
+]
+
+[[package]]
+name = "nostr-connect"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d7366ee1dfa57b479cf56256e18301cb3088f7068ceba01d446db0332b4cb2"
+dependencies = [
+ "async-utility",
+ "nostr",
+ "nostr-relay-pool",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2317,6 +2400,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2729,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3174,10 +3283,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marmot-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "CLI tool for Marmot/Whitenoise E2E encrypted messaging over Nostr"
 
@@ -12,6 +12,8 @@ mdk-storage-traits = { git = "https://github.com/parres-hq/mdk", rev = "5ef0c607
 # Match nostr versions with MDK (0.44)
 nostr = { version = "0.44", features = ["std", "nip44", "nip59"] }
 nostr-sdk = { version = "0.44", features = ["nip59"] }
+# NIP-46 remote signing
+nostr-connect = "0.44"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
@@ -20,3 +22,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 hex = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
+url = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -197,6 +197,59 @@ You can't message someone who hasn't published a key package.
 
 ---
 
+## NIP-46 Bunker Issues
+
+### "Failed to connect to bunker"
+
+**Possible causes:**
+1. Bunker process isn't running
+2. Relay specified in bunker URI is down
+3. Connection token/secret has been revoked
+4. Network connectivity issues
+
+**Debug steps:**
+```bash
+# Check signer status
+marmot-cli signer-status
+
+# Verify the bunker config
+cat ~/.marmot-cli/marmot.bunker.json
+
+# Check if the relay is reachable
+websocat wss://relay.nsec.app
+```
+
+### "Bunker signing failed"
+
+**What it means:** The bunker received the signing request but rejected it.
+
+**Common causes:**
+- Bunker rate limit exceeded
+- Bunker ACL doesn't allow this operation
+- Bunker requires manual approval for this event kind
+
+**Solution:** Check your bunker's admin panel/logs for rejected requests.
+
+### "Identity mismatch" during migration
+
+**What it means:** The bunker controls a different Nostr identity than your current nsec.
+
+**This is a safety check.** Your MLS group state is tied to your public key. Switching to a different identity would break all existing chats.
+
+**Solution:** Make sure the bunker is configured with the same nsec you're currently using.
+
+### Signing latency with bunker
+
+Each signing operation requires a round-trip to the bunker via relay. For high-frequency operations:
+
+- Key package publishing: ~1-2 seconds (one-time)
+- Sending messages: ~1 second per message (MLS message creation is local, only the Nostr event needs signing)
+- Gift wrapping: ~1-2 seconds (NIP-44 encryption via bunker)
+
+**Tip:** MLS message creation (`create_message`) doesn't require the bunker — only the outer Nostr event wrapping does. Most of the crypto work is done locally.
+
+---
+
 ## Getting Help
 
 1. **GitHub Issues:** https://github.com/kai-familiar/marmot-cli/issues

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,27 @@
 // Marmot CLI - E2E encrypted messaging over Nostr for agents
 // Uses the Marmot Development Kit (MDK) for MLS protocol
 // Compatible with Whitenoise (uses same MDK version)
+//
+// Supports two signing modes:
+// - Direct nsec (legacy, convenient for development)
+// - NIP-46 remote signing via bunker:// (recommended for production/agents)
+
+mod nip46;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use mdk_core::prelude::*;
 use mdk_sqlite_storage::MdkSqliteStorage;
 use nostr::prelude::*;
-use nostr::nips::nip59;
 use nostr_sdk::prelude::*;
 use serde::Serialize;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::io::Write;
+use tokio::sync::Mutex;
+
+use nip46::{AuditLog, BunkerConfig, MarmotSigner, SigningMode};
 
 /// JSON payload for --on-message callback
 #[derive(Serialize)]
@@ -30,14 +39,19 @@ struct MessagePayload {
 #[derive(Parser)]
 #[command(name = "marmot-cli")]
 #[command(about = "E2E encrypted messaging over Nostr using Marmot/MLS protocol")]
+#[command(version)]
 struct Cli {
     /// Path to the database file
     #[arg(short, long, default_value = "~/.marmot-cli/marmot.db")]
     db: String,
 
-    /// Nostr private key (nsec or hex)
+    /// Nostr private key (nsec or hex) — use bunker mode for production
     #[arg(short, long, env = "NOSTR_NSEC", hide_env_values = true)]
     nsec: Option<String>,
+
+    /// Bunker URI for NIP-46 remote signing (recommended for agents)
+    #[arg(short, long, env = "NOSTR_BUNKER")]
+    bunker: Option<String>,
 
     /// Relay URLs (comma-separated)
     #[arg(short, long, default_value = "wss://relay.damus.io,wss://relay.primal.net,wss://nos.lol")]
@@ -58,14 +72,14 @@ enum Commands {
         /// Use existing nsec (otherwise generates new keys)
         #[arg(long)]
         nsec: Option<String>,
+        /// Use NIP-46 bunker for remote signing (recommended for agents)
+        #[arg(long)]
+        bunker: Option<String>,
     },
-
     /// Show current identity info
     Whoami,
-
     /// Publish key package to relays (required before others can message you)
     PublishKeyPackage,
-
     /// Create a new group/chat with another user
     CreateChat {
         /// The npub of the user to chat with
@@ -74,10 +88,8 @@ enum Commands {
         #[arg(short, long)]
         name: Option<String>,
     },
-
     /// List all groups/chats
     ListChats,
-
     /// Send a message to a group
     Send {
         /// Group ID (hex, from list-chats). Can be partial.
@@ -86,110 +98,94 @@ enum Commands {
         /// Message content
         message: String,
     },
-
     /// Receive and process pending messages
     Receive,
-
     /// Accept a pending welcome (join a group you've been invited to)
     AcceptWelcome {
         /// Welcome event ID (from receive output)
         event_id: String,
     },
-
     /// Listen for incoming messages (runs continuously)
     Listen {
         /// Poll interval in seconds
         #[arg(short, long, default_value_t = 5)]
         interval: u64,
-
         /// Script/command to execute for each message (receives JSON via stdin)
         #[arg(long)]
         on_message: Option<String>,
     },
-
     /// Fetch key package for a user
     FetchKeyPackage {
         /// The npub to fetch key package for
         npub: String,
     },
+    /// Migrate from direct nsec to NIP-46 bunker signing (atomic)
+    MigrateToBunker {
+        /// Bunker URI: bunker://<pubkey>?relay=wss://...&secret=TOKEN
+        bunker: String,
+    },
+    /// Show signing mode and bunker connection status
+    SignerStatus,
 }
 
 struct MarmotCli {
-    keys: Keys,
+    signer: MarmotSigner,
     mdk: MDK<MdkSqliteStorage>,
     relays: Vec<RelayUrl>,
     client: Client,
+    #[allow(dead_code)]
+    db_path: PathBuf,
 }
 
 impl MarmotCli {
-    async fn new(db_path: PathBuf, nsec: Option<String>, relay_urls: Vec<String>) -> Result<Self> {
-        // Create database directory if needed
+    async fn new(
+        db_path: PathBuf,
+        nsec: Option<String>,
+        bunker_uri: Option<String>,
+        relay_urls: Vec<String>,
+    ) -> Result<Self> {
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        // Load keys (fail-fast if not provided)
-        let keys = if let Some(nsec) = nsec {
-            if nsec.starts_with("nsec") {
-                Keys::parse(&nsec)?
-            } else {
-                // Try as hex
-                let secret_key = SecretKey::from_hex(&nsec)?;
-                Keys::new(secret_key)
-            }
-        } else {
-            anyhow::bail!(
-                "No credentials provided. Set NOSTR_NSEC environment variable or use --nsec flag.\n\
-                 \n\
-                 For OpenClaw/wrapper users:\n\
-                 - Create .credentials/nostr.json with {{\"nsec\": \"nsec1...\"}}\n\
-                 - Use the ./marmot wrapper script instead of the raw binary\n\
-                 \n\
-                 For direct usage:\n\
-                 - export NOSTR_NSEC=\"nsec1...\"\n\
-                 - Or: marmot-cli --nsec \"nsec1...\" <command>\n\
-                 \n\
-                 This prevents accidental key package proliferation and MLS group state issues."
-            );
-        };
+        let audit = Arc::new(Mutex::new(AuditLog::new(&db_path)));
 
-        // Initialize MDK with SQLite storage
-        // Note: Using unencrypted storage for headless CLI environments.
-        // The database contains MLS group state and exporter secrets.
-        // In production GUI apps, use MdkSqliteStorage::new() with keyring integration.
-        // TODO: Add optional keyring support via --encrypted flag
+        let signing_mode = SigningMode::resolve(
+            nsec.as_deref(),
+            bunker_uri.as_deref(),
+            &db_path,
+        )?;
+
+        let signer = MarmotSigner::new(signing_mode, &db_path, audit).await?;
+
         let storage = MdkSqliteStorage::new_unencrypted(&db_path)
             .context("Failed to create SQLite storage")?;
         let mdk = MDK::new(storage);
 
-        // Parse relay URLs
         let relays: Vec<RelayUrl> = relay_urls
             .iter()
             .filter_map(|url| RelayUrl::parse(url).ok())
             .collect();
 
-        // Initialize Nostr client
-        let client = Client::builder().signer(keys.clone()).build();
+        let client = signer.build_client().await?;
         for relay in &relays {
             client.add_relay(relay.as_str()).await?;
         }
         client.connect().await;
-        
-        // Wait for relay connections to establish
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
-        Ok(Self {
-            keys,
-            mdk,
-            relays,
-            client,
-        })
+        Ok(Self { signer, mdk, relays, client, db_path })
     }
 
     fn whoami(&self) {
         println!("=== Marmot CLI Identity ===");
-        println!("npub: {}", self.keys.public_key().to_bech32().unwrap());
-        println!("hex:  {}", self.keys.public_key());
+        println!("npub:   {}", self.signer.public_key().to_bech32().unwrap());
+        println!("hex:    {}", self.signer.public_key());
+        println!("signer: {}", self.signer.mode_description());
+        if self.signer.is_bunker() {
+            println!("\n🔐 Using NIP-46 remote signing (bunker mode)");
+            println!("   Private key never leaves the bunker.");
+        }
         println!("\nRelays:");
         for relay in &self.relays {
             println!("  - {}", relay);
@@ -198,23 +194,23 @@ impl MarmotCli {
 
     async fn publish_key_package(&self) -> Result<()> {
         println!("Creating and publishing key package...");
-        
+        if self.signer.is_bunker() {
+            println!("   (bunker must be online for signing)");
+        }
+
         let (key_package_encoded, tags) = self.mdk
-            .create_key_package_for_event(&self.keys.public_key(), self.relays.clone())?;
+            .create_key_package_for_event(&self.signer.public_key(), self.relays.clone())?;
 
-        // Build event with MDK-generated tags + encoding tag
-        let event = EventBuilder::new(Kind::MlsKeyPackage, key_package_encoded)
+        let builder = EventBuilder::new(Kind::MlsKeyPackage, key_package_encoded)
             .tags(tags)
-            .tag(Tag::custom(TagKind::custom("encoding"), ["hex"]))
-            .sign(&self.keys)
-            .await?;
+            .tag(Tag::custom(TagKind::custom("encoding"), ["hex"]));
 
+        let event = self.signer.sign_event(builder).await?;
         let output = self.client.send_event(&event).await?;
-        
+
         println!("✓ Key package published!");
         println!("  Event ID: {}", output.id());
         println!("  Published to {} relays", output.success.len());
-        
         Ok(())
     }
 
@@ -224,123 +220,88 @@ impl MarmotCli {
         } else {
             PublicKey::from_hex(npub)?
         };
-
         println!("Fetching key package for {}...", &pubkey.to_bech32().unwrap()[..20]);
 
-        let filter = Filter::new()
-            .kind(Kind::MlsKeyPackage)
-            .author(pubkey)
-            .limit(1);
-
+        let filter = Filter::new().kind(Kind::MlsKeyPackage).author(pubkey).limit(1);
         let events = self.client
             .fetch_events(filter, std::time::Duration::from_secs(10))
             .await?;
 
-        let event = events
-            .first()
-            .cloned()
+        let event = events.first().cloned()
             .context("No key package found for this user. They need to run `publish-key-package` first.")?;
-
         println!("✓ Found key package (event: {})", &event.id.to_hex()[..16]);
         Ok(event)
     }
 
     async fn create_chat(&self, npub: &str, name: Option<String>) -> Result<()> {
-        // Fetch the other user's key package
         let other_key_package_event = self.fetch_key_package(npub).await?;
         let other_pubkey = other_key_package_event.pubkey;
-
         let group_name = name.unwrap_or_else(|| {
             format!("Chat with {}", &other_pubkey.to_bech32().unwrap()[..20])
         });
-
         println!("Creating group '{}'...", group_name);
 
-        // Creator is the admin; both are members (members are added via key packages)
         let config = NostrGroupConfigData::new(
-            group_name.clone(),
-            "Marmot CLI chat".to_string(),
-            None, None, None,
-            self.relays.clone(),
-            vec![self.keys.public_key()], // only creator is admin
+            group_name.clone(), "Marmot CLI chat".to_string(),
+            None, None, None, self.relays.clone(), vec![self.signer.public_key()],
         );
-
         let result = self.mdk.create_group(
-            &self.keys.public_key(),
-            vec![other_key_package_event],
-            config,
+            &self.signer.public_key(), vec![other_key_package_event], config,
         )?;
 
-        // Gift-wrap and send welcome to each invited member
         for welcome_rumor in &result.welcome_rumors {
-            let gift_wrap = EventBuilder::gift_wrap(
-                &self.keys,
-                &other_pubkey,
-                welcome_rumor.clone(),
-                [],
-            ).await?;
-            
+            let gift_wrap = self.signer.gift_wrap(&other_pubkey, welcome_rumor.clone()).await?;
             let send_result = self.client.send_event(&gift_wrap).await?;
             println!("✓ Welcome sent to {} relays", send_result.success.len());
         }
 
         let mls_group_id = hex::encode(result.group.mls_group_id.as_slice());
         let nostr_group_id = hex::encode(&result.group.nostr_group_id);
-
         println!("\n✓ Group created!");
         println!("  Name:           {}", group_name);
         println!("  MLS Group ID:   {}", mls_group_id);
         println!("  Nostr Group ID: {}", nostr_group_id);
         println!("\nUse this to send messages:");
         println!("  marmot-cli send -g {} \"Hello!\"", &mls_group_id[..16]);
-
         Ok(())
     }
 
     fn list_chats(&self) -> Result<()> {
         let groups = self.mdk.get_groups()?;
-        
         if groups.is_empty() {
             println!("No chats found. Create one with: marmot-cli create-chat <npub>");
             return Ok(());
         }
-
         println!("=== Your Chats ({}) ===\n", groups.len());
         for group in groups {
             let mls_id = hex::encode(group.mls_group_id.as_slice());
             println!("📱 {} [epoch {}]", group.name, group.epoch);
             println!("   MLS ID: {} (use first 8+ chars with -g)", mls_id);
             println!("   Nostr ID: {}", hex::encode(&group.nostr_group_id));
-            
             if let Ok(members) = self.mdk.get_members(&group.mls_group_id) {
                 println!("   Members: {}", members.len());
                 for member in &members {
                     let bech32 = member.to_bech32().unwrap_or_else(|_| member.to_string());
-                    let is_me = *member == self.keys.public_key();
+                    let is_me = *member == self.signer.public_key();
                     println!("     {} {}", if is_me { "→" } else { " " }, &bech32[..20]);
                 }
             }
-
             if let Some(last) = &group.last_message_at {
                 println!("   Last message: {}", last);
             }
             println!();
         }
-
         Ok(())
     }
 
-    /// Resolve a potentially partial group ID to a full MLS group ID
     fn resolve_group_id(&self, partial: &str) -> Result<GroupId> {
         let groups = self.mdk.get_groups()?;
         let partial_lower = partial.to_lowercase();
-        
         let matches: Vec<_> = groups.iter().filter(|g| {
             let mls_hex = hex::encode(g.mls_group_id.as_slice());
             let nostr_hex = hex::encode(&g.nostr_group_id);
             mls_hex.starts_with(&partial_lower) || nostr_hex.starts_with(&partial_lower)
         }).collect();
-
         match matches.len() {
             0 => anyhow::bail!("No group found matching '{}'", partial),
             1 => Ok(matches[0].mls_group_id.clone()),
@@ -356,16 +317,10 @@ impl MarmotCli {
 
     async fn send_message(&self, group_id_str: &str, message: &str) -> Result<()> {
         let mls_group_id = self.resolve_group_id(group_id_str)?;
-        
-        // Create the inner message event (Kind 9 = chat message per NIP-EE/Marmot spec)
-        // This MUST be unsigned per spec
         let rumor = EventBuilder::new(Kind::Custom(9), message)
-            .build(self.keys.public_key());
-
+            .build(self.signer.public_key());
         let message_event = self.mdk.create_message(&mls_group_id, rumor)?;
-
         let send_result = self.client.send_event(&message_event).await?;
-        
         println!("✓ Message sent to {} relays", send_result.success.len());
         Ok(())
     }
@@ -375,40 +330,33 @@ impl MarmotCli {
         let mut messages_found = 0;
         let mut payloads: Vec<MessagePayload> = Vec::new();
 
-        // === Phase 1: Fetch and process gift-wrapped welcome messages ===
+        // Phase 1: Fetch and process gift-wrapped welcome messages
         let filter = Filter::new()
             .kind(Kind::GiftWrap)
-            .pubkey(self.keys.public_key())
+            .pubkey(self.signer.public_key())
             .limit(100);
-
         let events = self.client
             .fetch_events(filter, std::time::Duration::from_secs(10))
             .await?;
 
         for event in events.iter() {
-            match nip59::extract_rumor(&self.keys, event).await {
+            match self.signer.extract_rumor(event).await {
                 Ok(unwrapped) => {
-                    // Kind 444 = MLS Welcome
                     if unwrapped.rumor.kind == Kind::MlsWelcome {
                         match self.mdk.process_welcome(&event.id, &unwrapped.rumor) {
                             Ok(_) => {
                                 welcomes_found += 1;
                                 println!("📨 New welcome received (event: {})", &event.id.to_hex()[..16]);
                             }
-                            Err(e) => {
-                                // May already be processed
-                                tracing::debug!("Welcome processing: {}", e);
-                            }
+                            Err(e) => { tracing::debug!("Welcome processing: {}", e); }
                         }
                     }
                 }
-                Err(e) => {
-                    tracing::debug!("Could not unwrap gift-wrap: {}", e);
-                }
+                Err(e) => { tracing::debug!("Could not unwrap gift-wrap: {}", e); }
             }
         }
 
-        // === Phase 2: Check for pending welcomes and show them ===
+        // Phase 2: Check for pending welcomes
         if let Ok(pending) = self.mdk.get_pending_welcomes(None) {
             for welcome in &pending {
                 println!("⏳ Pending welcome: '{}' (event: {})", welcome.group_name, &welcome.id.to_hex()[..16]);
@@ -416,15 +364,14 @@ impl MarmotCli {
             }
         }
 
-        // === Phase 3: Fetch and process group messages for all groups ===
+        // Phase 3: Fetch and process group messages
         let groups = self.mdk.get_groups()?;
         for group in &groups {
             let nostr_group_id = hex::encode(&group.nostr_group_id);
             let filter = Filter::new()
-                .kind(Kind::MlsGroupMessage) // Kind 445
+                .kind(Kind::MlsGroupMessage)
                 .custom_tag(SingleLetterTag::lowercase(Alphabet::H), nostr_group_id.clone())
                 .limit(50);
-
             let events = self.client
                 .fetch_events(filter, std::time::Duration::from_secs(10))
                 .await?;
@@ -435,19 +382,15 @@ impl MarmotCli {
                         match result {
                             MessageProcessingResult::ApplicationMessage(msg) => {
                                 messages_found += 1;
-                                let sender = msg.pubkey.to_bech32()
-                                    .unwrap_or_else(|_| "unknown".to_string());
-                                let is_me = msg.pubkey == self.keys.public_key();
+                                let sender = msg.pubkey.to_bech32().unwrap_or_else(|_| "unknown".to_string());
+                                let is_me = msg.pubkey == self.signer.public_key();
                                 let prefix = if is_me { "→ You".to_string() } else { sender.clone() };
                                 println!("[{}] {}: {}", group.name, prefix, msg.content);
-
-                                // Build payload for callback
                                 payloads.push(MessagePayload {
                                     message_id: event.id.to_hex(),
                                     group_id: hex::encode(group.mls_group_id.as_slice()),
                                     group_name: group.name.clone(),
-                                    sender,
-                                    sender_hex: msg.pubkey.to_hex(),
+                                    sender, sender_hex: msg.pubkey.to_hex(),
                                     content: msg.content.clone(),
                                     timestamp: event.created_at.as_secs(),
                                     is_me,
@@ -459,9 +402,7 @@ impl MarmotCli {
                             _ => {}
                         }
                     }
-                    Err(e) => {
-                        tracing::debug!("Message processing: {}", e);
-                    }
+                    Err(e) => { tracing::debug!("Message processing: {}", e); }
                 }
             }
         }
@@ -469,21 +410,15 @@ impl MarmotCli {
         Ok((welcomes_found, messages_found, payloads))
     }
 
-    /// Invoke callback script with message payload as JSON stdin
     fn invoke_callback(script: &str, payload: &MessagePayload) -> Result<i32> {
         let json = serde_json::to_string(payload)?;
-        
         let mut child = Command::new("sh")
-            .arg("-c")
-            .arg(script)
+            .arg("-c").arg(script)
             .stdin(Stdio::piped())
-            .spawn()
-            .context("Failed to spawn callback process")?;
-
+            .spawn().context("Failed to spawn callback process")?;
         if let Some(mut stdin) = child.stdin.take() {
             stdin.write_all(json.as_bytes())?;
         }
-
         let status = child.wait()?;
         Ok(status.code().unwrap_or(-1))
     }
@@ -492,62 +427,198 @@ impl MarmotCli {
         let event_id = EventId::from_hex(event_id_str)
             .or_else(|_| EventId::from_bech32(event_id_str))
             .context("Invalid event ID")?;
-
         let welcome = self.mdk.get_welcome(&event_id)?
             .context("Welcome not found. Run `receive` first to fetch pending welcomes.")?;
-
         self.mdk.accept_welcome(&welcome)?;
-
         println!("✓ Welcome accepted! You've joined the group.");
-        
-        // Show the group we just joined
         let groups = self.mdk.get_groups()?;
         if let Some(latest) = groups.last() {
             println!("  Group: {}", latest.name);
             println!("  MLS ID: {}", hex::encode(latest.mls_group_id.as_slice()));
         }
-
         Ok(())
     }
+}
+
+/// Migrate from nsec to bunker mode (standalone, doesn't need full MarmotCli)
+async fn migrate_to_bunker(db_path: &PathBuf, bunker_uri: &str, current_nsec: Option<&str>) -> Result<()> {
+    // Step 1: Parse the bunker URI
+    println!("🔐 Migrating to NIP-46 bunker signing...\n");
+    let mut config = BunkerConfig::from_bunker_uri(bunker_uri)?;
+
+    // Step 2: Check if there's already a bunker config
+    if BunkerConfig::load(db_path)?.is_some() {
+        anyhow::bail!(
+            "A bunker configuration already exists.\n\
+             Delete it first with: rm {}\n\
+             Or use init --bunker to start fresh.",
+            BunkerConfig::config_path(db_path).display()
+        );
+    }
+
+    // Step 3: Connect to bunker and get user pubkey
+    println!("   Connecting to bunker...");
+    let uri = config.to_nostr_connect_uri()?;
+    let client_keys = config.client_keys()?;
+    let connect = nostr_connect::prelude::NostrConnect::new(
+        uri, client_keys, std::time::Duration::from_secs(30), None,
+    ).map_err(|e| anyhow::anyhow!("Failed to create NIP-46 client: {}", e))?;
+
+    let bunker_pubkey = connect.get_public_key().await
+        .map_err(|e| anyhow::anyhow!("Failed to connect to bunker: {}", e))?;
+    println!("   Bunker user pubkey: {}", bunker_pubkey.to_bech32().unwrap_or_default());
+
+    // Step 4: If we have the current nsec, verify identity matches
+    if let Some(nsec) = current_nsec {
+        let current_keys = if nsec.starts_with("nsec") {
+            Keys::parse(nsec)?
+        } else {
+            Keys::new(SecretKey::from_hex(nsec)?)
+        };
+
+        if current_keys.public_key() != bunker_pubkey {
+            anyhow::bail!(
+                "Identity mismatch!\n\
+                 Current nsec pubkey: {}\n\
+                 Bunker pubkey:       {}\n\n\
+                 The bunker must control the same Nostr identity.\n\
+                 Your MLS group state is tied to your public key.",
+                current_keys.public_key().to_bech32().unwrap_or_default(),
+                bunker_pubkey.to_bech32().unwrap_or_default()
+            );
+        }
+        println!("   ✓ Identity verified (pubkeys match)");
+    } else {
+        println!("   ⚠️  No current nsec provided — cannot verify identity match.");
+        println!("   Make sure the bunker controls the same key used for your MLS groups.");
+    }
+
+    // Step 5: Save config atomically
+    config.update_connected(Some(bunker_pubkey));
+    config.save(db_path)?;
+    println!("   ✓ Bunker config saved to {}", BunkerConfig::config_path(db_path).display());
+
+    // Step 6: Shutdown bunker connection
+    connect.shutdown().await;
+
+    println!("\n✅ Migration complete!");
+    println!("\nNext steps:");
+    println!("  1. Remove NOSTR_NSEC from your environment");
+    println!("  2. Remove nsec from .credentials/nostr.json (if used)");
+    println!("  3. Test: marmot-cli whoami  (should show bunker mode)");
+    println!("  4. Keep your bunker process running for signing operations");
+    println!("\n🔒 Your nsec is no longer needed by marmot-cli.");
+    Ok(())
+}
+
+fn show_signer_status(db_path: &PathBuf, nsec: Option<&str>, bunker_uri: Option<&str>) -> Result<()> {
+    println!("=== Marmot CLI Signer Status ===\n");
+
+    // Check for bunker config
+    if let Some(config) = BunkerConfig::load(db_path)? {
+        println!("Mode: 🔐 NIP-46 Bunker (stored)");
+        println!("  Remote signer: {}", &config.remote_signer_pubkey[..16]);
+        println!("  Relays: {}", config.relays.join(", "));
+        if let Some(ref pk) = config.user_pubkey {
+            println!("  User pubkey: {}...", &pk[..16]);
+        }
+        println!("  Created: {}", config.created_at);
+        if let Some(ref last) = config.last_connected {
+            println!("  Last connected: {}", last);
+        }
+        println!("  Config file: {}", BunkerConfig::config_path(db_path).display());
+    } else if bunker_uri.is_some() {
+        println!("Mode: 🔐 NIP-46 Bunker (from CLI/env, not yet stored)");
+    } else if nsec.is_some() {
+        println!("Mode: 🔑 Direct nsec");
+        println!("  ⚠️  Consider migrating to bunker mode for production use:");
+        println!("     marmot-cli migrate-to-bunker --bunker \"bunker://...\"");
+    } else {
+        println!("Mode: ❌ No credentials configured");
+    }
+
+    // Check audit log
+    let audit_path = db_path.with_extension("audit.jsonl");
+    if audit_path.exists() {
+        if let Ok(metadata) = std::fs::metadata(&audit_path) {
+            println!("\nAudit log: {} ({} bytes)", audit_path.display(), metadata.len());
+        }
+    }
+
+    Ok(())
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Configure logging based on quiet flag
     use tracing_subscriber::EnvFilter;
-    
-    let default_filter = if cli.quiet {
-        "warn,nostr_relay_pool=off"
-    } else {
-        "info"
-    };
-    
+    let default_filter = if cli.quiet { "warn,nostr_relay_pool=off" } else { "info" };
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new(default_filter));
-
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
         .with_env_filter(filter)
         .with_target(true)
-        .with_writer(std::io::stderr)  // Send logs to stderr, not stdout
+        .with_writer(std::io::stderr)
         .finish();
     tracing::subscriber::set_global_default(subscriber)?;
 
-    // Expand ~ in path
     let db_path = PathBuf::from(cli.db.replace("~", &std::env::var("HOME").unwrap_or_default()));
-    
     let relay_urls: Vec<String> = cli.relays.split(',').map(|s| s.trim().to_string()).collect();
-    
-    let marmot = MarmotCli::new(db_path, cli.nsec, relay_urls).await?;
+
+    // Handle commands that don't need full MarmotCli initialization
+    match &cli.command {
+        Commands::MigrateToBunker { bunker } => {
+            return migrate_to_bunker(&db_path, bunker, cli.nsec.as_deref()).await;
+        }
+        Commands::SignerStatus => {
+            return show_signer_status(&db_path, cli.nsec.as_deref(), cli.bunker.as_deref());
+        }
+        _ => {}
+    }
+
+    // For Init with bunker, handle specially
+    if let Commands::Init { nsec: _init_nsec, bunker: Some(bunker_uri) } = &cli.command {
+        // Store bunker config and show identity
+        let mut config = BunkerConfig::from_bunker_uri(bunker_uri)?;
+        println!("🔐 Initializing with NIP-46 bunker...");
+
+        let uri = config.to_nostr_connect_uri()?;
+        let client_keys = config.client_keys()?;
+        let connect = nostr_connect::prelude::NostrConnect::new(
+            uri, client_keys, std::time::Duration::from_secs(30), None,
+        ).map_err(|e| anyhow::anyhow!("Failed to create NIP-46 client: {}", e))?;
+
+        let pubkey = connect.get_public_key().await
+            .map_err(|e| anyhow::anyhow!("Failed to connect to bunker: {}", e))?;
+
+        config.update_connected(Some(pubkey));
+
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        config.save(&db_path)?;
+        connect.shutdown().await;
+
+        println!("✓ Bunker configured!");
+        println!("  npub: {}", pubkey.to_bech32().unwrap_or_default());
+        println!("  hex:  {}", pubkey);
+        println!("  Config: {}", BunkerConfig::config_path(&db_path).display());
+        println!("\nNext: marmot-cli publish-key-package");
+        return Ok(());
+    }
+
+    // Merge init nsec with global nsec
+    let effective_nsec = match &cli.command {
+        Commands::Init { nsec: Some(init_nsec), .. } => Some(init_nsec.clone()),
+        _ => cli.nsec,
+    };
+
+    let marmot = MarmotCli::new(db_path, effective_nsec, cli.bunker, relay_urls).await?;
 
     match cli.command {
-        Commands::Init { nsec } => {
-            if nsec.is_some() {
-                println!("Initialized with provided nsec");
-            } else {
-                println!("Generated new identity");
-            }
+        Commands::Init { .. } => {
+            println!("Initialized with provided credentials");
             marmot.whoami();
         }
         Commands::Whoami => {
@@ -586,28 +657,16 @@ async fn main() -> Result<()> {
             }
             loop {
                 let (w, m, payloads) = marmot.receive_messages().await?;
-                
-                // If callback is set, invoke it for each message
                 if let Some(ref script) = on_message {
                     for payload in &payloads {
-                        // Skip our own messages in callback
-                        if payload.is_me {
-                            continue;
-                        }
+                        if payload.is_me { continue; }
                         match MarmotCli::invoke_callback(script, payload) {
-                            Ok(0) => {
-                                tracing::debug!("Callback succeeded for message {}", payload.message_id);
-                            }
-                            Ok(code) => {
-                                eprintln!("⚠️ Callback exited with code {} for message {}", code, &payload.message_id[..16]);
-                            }
-                            Err(e) => {
-                                eprintln!("❌ Callback failed for message {}: {}", &payload.message_id[..16], e);
-                            }
+                            Ok(0) => { tracing::debug!("Callback succeeded for message {}", payload.message_id); }
+                            Ok(code) => { eprintln!("⚠️ Callback exited with code {} for message {}", code, &payload.message_id[..16]); }
+                            Err(e) => { eprintln!("❌ Callback failed for message {}: {}", &payload.message_id[..16], e); }
                         }
                     }
                 }
-                
                 if w > 0 || m > 0 {
                     println!("--- {} welcome(s), {} message(s) ---", w, m);
                 }
@@ -616,6 +675,9 @@ async fn main() -> Result<()> {
         }
         Commands::FetchKeyPackage { npub } => {
             marmot.fetch_key_package(&npub).await?;
+        }
+        Commands::MigrateToBunker { .. } | Commands::SignerStatus => {
+            unreachable!("Handled above");
         }
     }
 

--- a/src/nip46/audit.rs
+++ b/src/nip46/audit.rs
@@ -1,0 +1,103 @@
+//! Audit logging for signing operations
+//!
+//! Records all signing requests, bunker connections, and key migrations
+//! to a local log file for security review.
+
+use std::path::{Path, PathBuf};
+use std::io::Write;
+
+use serde::Serialize;
+
+/// Audit log entry
+#[derive(Debug, Serialize)]
+struct AuditEntry {
+    timestamp: String,
+    operation: String,
+    details: String,
+}
+
+/// Append-only audit log for signing operations
+pub struct AuditLog {
+    path: PathBuf,
+    enabled: bool,
+}
+
+impl AuditLog {
+    /// Create a new audit log at the given path
+    pub fn new(db_path: &Path) -> Self {
+        let path = db_path.with_extension("audit.jsonl");
+        Self {
+            path,
+            enabled: true,
+        }
+    }
+
+    /// Create a disabled audit log (for testing)
+    #[allow(dead_code)]
+    pub fn disabled() -> Self {
+        Self {
+            path: PathBuf::from("/dev/null"),
+            enabled: false,
+        }
+    }
+
+    /// Record an audit event
+    pub fn record(&mut self, operation: &str, details: &str) {
+        if !self.enabled {
+            return;
+        }
+
+        let entry = AuditEntry {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            operation: operation.to_string(),
+            details: details.to_string(),
+        };
+
+        // Best-effort append — don't fail the operation if audit logging fails
+        if let Ok(json) = serde_json::to_string(&entry) {
+            if let Ok(mut file) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.path)
+            {
+                let _ = writeln!(file, "{}", json);
+            }
+        }
+    }
+
+    /// Get the audit log file path
+    #[allow(dead_code)]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_audit_log_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("marmot.db");
+
+        let mut log = AuditLog::new(&db_path);
+        log.record("test_op", "test details");
+        log.record("test_op2", "more details");
+
+        let content = std::fs::read_to_string(log.path()).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let entry: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(entry["operation"], "test_op");
+        assert_eq!(entry["details"], "test details");
+    }
+
+    #[test]
+    fn test_audit_log_disabled() {
+        let mut log = AuditLog::disabled();
+        // Should not panic
+        log.record("test", "test");
+    }
+}

--- a/src/nip46/config.rs
+++ b/src/nip46/config.rs
@@ -1,0 +1,357 @@
+//! Bunker configuration and signing mode management
+//!
+//! Handles parsing bunker:// URIs, storing/loading bunker config from a JSON
+//! sidecar file alongside the marmot.db, and determining which signing mode
+//! to use.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use nostr::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// Persistent bunker connection configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BunkerConfig {
+    /// The remote signer's public key (hex)
+    pub remote_signer_pubkey: String,
+    /// Relay URLs the bunker listens on
+    pub relays: Vec<String>,
+    /// Connection secret/token (optional, used for initial connect)
+    pub secret: Option<String>,
+    /// Our local client keypair (hex) for NIP-46 communication
+    /// Generated once and persisted so the bunker recognizes us
+    pub client_secret_key: String,
+    /// The user's public key as reported by the bunker (hex)
+    /// Cached after first successful connection
+    pub user_pubkey: Option<String>,
+    /// When this config was created
+    pub created_at: String,
+    /// When last successfully connected to bunker
+    pub last_connected: Option<String>,
+}
+
+impl BunkerConfig {
+    /// Parse a bunker:// URI into a BunkerConfig
+    ///
+    /// Format: bunker://<remote-signer-pubkey>?relay=wss://...&secret=TOKEN
+    pub fn from_bunker_uri(uri: &str) -> Result<Self> {
+        // Validate it parses as a NostrConnectURI
+        let parsed = NostrConnectURI::parse(uri)
+            .context("Invalid bunker:// URI format")?;
+
+        // Extract components
+        let (remote_pubkey, relays, secret) = match &parsed {
+            NostrConnectURI::Bunker {
+                remote_signer_public_key,
+                relays,
+                secret,
+            } => (
+                remote_signer_public_key.to_hex(),
+                relays.iter().map(|r| r.to_string()).collect::<Vec<_>>(),
+                secret.clone(),
+            ),
+            NostrConnectURI::Client { .. } => {
+                anyhow::bail!(
+                    "Expected bunker:// URI, got nostrconnect:// URI.\n\
+                     Use format: bunker://<pubkey>?relay=wss://...&secret=TOKEN"
+                );
+            }
+        };
+
+        if relays.is_empty() {
+            anyhow::bail!(
+                "Bunker URI must include at least one relay.\n\
+                 Example: bunker://<pubkey>?relay=wss://relay.nsec.app&secret=TOKEN"
+            );
+        }
+
+        // Generate a fresh client keypair for NIP-46 communication
+        let client_keys = Keys::generate();
+
+        Ok(BunkerConfig {
+            remote_signer_pubkey: remote_pubkey,
+            relays,
+            secret,
+            client_secret_key: client_keys.secret_key().to_secret_hex(),
+            user_pubkey: None,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            last_connected: None,
+        })
+    }
+
+    /// Reconstruct the NostrConnectURI from stored config
+    pub fn to_nostr_connect_uri(&self) -> Result<NostrConnectURI> {
+        let pubkey = PublicKey::from_hex(&self.remote_signer_pubkey)
+            .context("Invalid stored remote signer pubkey")?;
+        let relays: Vec<RelayUrl> = self
+            .relays
+            .iter()
+            .filter_map(|r| RelayUrl::parse(r).ok())
+            .collect();
+
+        Ok(NostrConnectURI::Bunker {
+            remote_signer_public_key: pubkey,
+            relays,
+            secret: self.secret.clone(),
+        })
+    }
+
+    /// Get the client Keys for NIP-46 communication
+    pub fn client_keys(&self) -> Result<Keys> {
+        let sk = SecretKey::from_hex(&self.client_secret_key)
+            .context("Invalid stored client secret key")?;
+        Ok(Keys::new(sk))
+    }
+
+    /// Get the cached user public key (if available)
+    pub fn cached_user_pubkey(&self) -> Option<PublicKey> {
+        self.user_pubkey
+            .as_ref()
+            .and_then(|hex| PublicKey::from_hex(hex).ok())
+    }
+
+    /// Config file path derived from the database path
+    pub fn config_path(db_path: &Path) -> PathBuf {
+        db_path.with_extension("bunker.json")
+    }
+
+    /// Load bunker config from disk
+    pub fn load(db_path: &Path) -> Result<Option<Self>> {
+        let path = Self::config_path(db_path);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content = std::fs::read_to_string(&path)
+            .context("Failed to read bunker config")?;
+        let config: BunkerConfig = serde_json::from_str(&content)
+            .context("Failed to parse bunker config")?;
+        Ok(Some(config))
+    }
+
+    /// Save bunker config to disk atomically
+    pub fn save(&self, db_path: &Path) -> Result<()> {
+        let path = Self::config_path(db_path);
+        let tmp_path = path.with_extension("json.tmp");
+
+        let content = serde_json::to_string_pretty(self)
+            .context("Failed to serialize bunker config")?;
+
+        // Write to temp file first
+        std::fs::write(&tmp_path, &content)
+            .context("Failed to write bunker config temp file")?;
+
+        // Atomic rename
+        std::fs::rename(&tmp_path, &path)
+            .context("Failed to atomically save bunker config")?;
+
+        // Set restrictive permissions (config contains client secret key)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            std::fs::set_permissions(&path, perms)?;
+        }
+
+        Ok(())
+    }
+
+    /// Delete bunker config from disk
+    #[allow(dead_code)]
+    pub fn delete(db_path: &Path) -> Result<()> {
+        let path = Self::config_path(db_path);
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .context("Failed to delete bunker config")?;
+        }
+        Ok(())
+    }
+
+    /// Update last_connected timestamp and optionally user pubkey
+    pub fn update_connected(&mut self, user_pubkey: Option<PublicKey>) {
+        self.last_connected = Some(chrono::Utc::now().to_rfc3339());
+        if let Some(pk) = user_pubkey {
+            self.user_pubkey = Some(pk.to_hex());
+        }
+    }
+}
+
+/// Signing mode for the CLI
+#[derive(Debug, Clone)]
+pub enum SigningMode {
+    /// Direct nsec — keys available locally
+    DirectKey(Keys),
+    /// NIP-46 remote signing via bunker
+    Bunker(BunkerConfig),
+}
+
+impl SigningMode {
+    /// Determine signing mode from CLI args and stored config
+    pub fn resolve(
+        nsec: Option<&str>,
+        bunker_uri: Option<&str>,
+        db_path: &Path,
+    ) -> Result<Self> {
+        // Explicit bunker URI takes highest priority
+        if let Some(uri) = bunker_uri {
+            let config = BunkerConfig::from_bunker_uri(uri)?;
+            return Ok(SigningMode::Bunker(config));
+        }
+
+        // Explicit nsec
+        if let Some(nsec) = nsec {
+            let keys = if nsec.starts_with("nsec") {
+                Keys::parse(nsec)?
+            } else {
+                let secret_key = SecretKey::from_hex(nsec)?;
+                Keys::new(secret_key)
+            };
+            return Ok(SigningMode::DirectKey(keys));
+        }
+
+        // Check for stored bunker config
+        if let Some(config) = BunkerConfig::load(db_path)? {
+            return Ok(SigningMode::Bunker(config));
+        }
+
+        // No credentials at all
+        anyhow::bail!(
+            "No credentials provided. Use one of:\n\
+             \n\
+             🔒 Bunker mode (recommended for agents):\n\
+             - marmot-cli --bunker \"bunker://<pubkey>?relay=wss://...&secret=TOKEN\" <command>\n\
+             - Or run: marmot-cli init --bunker \"bunker://...\"\n\
+             \n\
+             🔑 Direct key mode:\n\
+             - Set NOSTR_NSEC environment variable\n\
+             - Or: marmot-cli --nsec \"nsec1...\" <command>\n\
+             \n\
+             ⚠️  For long-running agents, bunker mode is strongly recommended.\n\
+             Direct nsec exposes your private key in the process environment."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_bunker_uri() {
+        let uri = "bunker://79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3?relay=wss://relay.nsec.app&secret=test123";
+        let config = BunkerConfig::from_bunker_uri(uri).unwrap();
+
+        assert_eq!(
+            config.remote_signer_pubkey,
+            "79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3"
+        );
+        assert_eq!(config.relays, vec!["wss://relay.nsec.app"]);
+        assert_eq!(config.secret, Some("test123".to_string()));
+        assert!(config.user_pubkey.is_none());
+        assert!(!config.client_secret_key.is_empty());
+    }
+
+    #[test]
+    fn test_parse_bunker_uri_no_secret() {
+        let uri = "bunker://79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3?relay=wss://relay.nsec.app";
+        let config = BunkerConfig::from_bunker_uri(uri).unwrap();
+
+        assert!(config.secret.is_none());
+    }
+
+    #[test]
+    fn test_parse_bunker_uri_multiple_relays() {
+        let uri = "bunker://79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3?relay=wss://relay.nsec.app&relay=wss://nos.lol";
+        let config = BunkerConfig::from_bunker_uri(uri).unwrap();
+
+        assert_eq!(config.relays.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_invalid_uri() {
+        assert!(BunkerConfig::from_bunker_uri("not-a-bunker-uri").is_err());
+        assert!(BunkerConfig::from_bunker_uri("https://example.com").is_err());
+    }
+
+    #[test]
+    fn test_roundtrip_nostr_connect_uri() {
+        let uri = "bunker://79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3?relay=wss://relay.nsec.app&secret=test123";
+        let config = BunkerConfig::from_bunker_uri(uri).unwrap();
+        let reconstructed = config.to_nostr_connect_uri().unwrap();
+        assert!(matches!(reconstructed, NostrConnectURI::Bunker { .. }));
+    }
+
+    #[test]
+    fn test_config_save_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("marmot.db");
+
+        let uri = "bunker://79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3?relay=wss://relay.nsec.app&secret=test123";
+        let config = BunkerConfig::from_bunker_uri(uri).unwrap();
+        config.save(&db_path).unwrap();
+
+        let loaded = BunkerConfig::load(&db_path).unwrap().unwrap();
+        assert_eq!(loaded.remote_signer_pubkey, config.remote_signer_pubkey);
+        assert_eq!(loaded.client_secret_key, config.client_secret_key);
+        assert_eq!(loaded.secret, config.secret);
+    }
+
+    #[test]
+    fn test_config_delete() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("marmot.db");
+
+        let uri = "bunker://79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3?relay=wss://relay.nsec.app";
+        let config = BunkerConfig::from_bunker_uri(uri).unwrap();
+        config.save(&db_path).unwrap();
+
+        assert!(BunkerConfig::load(&db_path).unwrap().is_some());
+        BunkerConfig::delete(&db_path).unwrap();
+        assert!(BunkerConfig::load(&db_path).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_signing_mode_resolve_nsec() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("marmot.db");
+
+        let keys = Keys::generate();
+        let nsec = keys.secret_key().to_bech32().unwrap();
+        let mode = SigningMode::resolve(Some(&nsec), None, &db_path).unwrap();
+        assert!(matches!(mode, SigningMode::DirectKey(_)));
+    }
+
+    #[test]
+    fn test_signing_mode_resolve_bunker() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("marmot.db");
+
+        let uri = "bunker://79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3?relay=wss://relay.nsec.app&secret=test";
+        let mode = SigningMode::resolve(None, Some(uri), &db_path).unwrap();
+        assert!(matches!(mode, SigningMode::Bunker(_)));
+    }
+
+    #[test]
+    fn test_signing_mode_resolve_stored_bunker() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("marmot.db");
+
+        // Save a bunker config
+        let uri = "bunker://79dff8f82963424e0bb02708a22e44b4980893e3a4be0fa3cb60a43b946764e3?relay=wss://relay.nsec.app";
+        let config = BunkerConfig::from_bunker_uri(uri).unwrap();
+        config.save(&db_path).unwrap();
+
+        // Should auto-detect stored bunker config
+        let mode = SigningMode::resolve(None, None, &db_path).unwrap();
+        assert!(matches!(mode, SigningMode::Bunker(_)));
+    }
+
+    #[test]
+    fn test_signing_mode_no_credentials() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("marmot.db");
+
+        let result = SigningMode::resolve(None, None, &db_path);
+        assert!(result.is_err());
+    }
+}

--- a/src/nip46/mod.rs
+++ b/src/nip46/mod.rs
@@ -1,0 +1,13 @@
+//! NIP-46 Remote Signing Support
+//!
+//! This module provides bunker:// URI handling, persistent storage of bunker
+//! connection parameters, and a unified signer abstraction that supports both
+//! direct nsec and NIP-46 remote signing modes.
+
+pub mod config;
+pub mod signer;
+pub mod audit;
+
+pub use config::{BunkerConfig, SigningMode};
+pub use signer::MarmotSigner;
+pub use audit::AuditLog;

--- a/src/nip46/signer.rs
+++ b/src/nip46/signer.rs
@@ -1,0 +1,299 @@
+//! Unified signer abstraction for marmot-cli
+//!
+//! MarmotSigner wraps both direct Keys and NostrConnect (NIP-46) signing,
+//! providing a consistent interface for the rest of the application.
+//! 
+//! Key design decisions:
+//! - The nostr-sdk Client uses NostrSigner trait for event signing
+//! - For direct mode, we use Keys (which impl NostrSigner)
+//! - For bunker mode, we use NostrConnect (which impl NostrSigner)
+//! - MDK operations need a PublicKey, not the full signer
+//! - Gift-wrap operations (NIP-59) need the full signer for encryption
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use nostr::prelude::*;
+use nostr_connect::prelude::*;
+use nostr_sdk::prelude::*;
+use tokio::sync::Mutex;
+
+use super::audit::AuditLog;
+use super::config::{BunkerConfig, SigningMode};
+
+/// NIP-46 connection timeout
+const BUNKER_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Unified signer that supports both direct keys and NIP-46 remote signing
+pub struct MarmotSigner {
+    /// The signing mode
+    mode: SignerMode,
+    /// User's public key (available in both modes)
+    public_key: PublicKey,
+    /// Audit logger for signing operations
+    audit: Arc<Mutex<AuditLog>>,
+    /// DB path for persisting config updates
+    #[allow(dead_code)]
+    db_path: std::path::PathBuf,
+}
+
+enum SignerMode {
+    /// Direct nsec signing (keys available locally)
+    Direct {
+        keys: Keys,
+    },
+    /// NIP-46 remote signing via bunker
+    Bunker {
+        connect: NostrConnect,
+        #[allow(dead_code)]
+        config: BunkerConfig,
+    },
+}
+
+impl MarmotSigner {
+    /// Create a new signer from the resolved signing mode
+    pub async fn new(
+        signing_mode: SigningMode,
+        db_path: &Path,
+        audit: Arc<Mutex<AuditLog>>,
+    ) -> Result<Self> {
+        match signing_mode {
+            SigningMode::DirectKey(keys) => {
+                let public_key = keys.public_key();
+
+                // Warn about direct key usage for long-running processes
+                if std::env::var("MARMOT_NO_NSEC_WARNING").is_err() {
+                    eprintln!(
+                        "⚠️  Using direct nsec signing. For long-running agents, consider \
+                         bunker mode:\n   marmot-cli init --bunker \"bunker://...\"\n"
+                    );
+                }
+
+                Ok(Self {
+                    mode: SignerMode::Direct { keys },
+                    public_key,
+                    audit,
+                    db_path: db_path.to_path_buf(),
+                })
+            }
+            SigningMode::Bunker(mut config) => {
+                // Create NostrConnect client
+                let uri = config.to_nostr_connect_uri()?;
+                let client_keys = config.client_keys()?;
+
+                eprintln!("🔐 Connecting to bunker...");
+
+                let connect = NostrConnect::new(uri, client_keys, BUNKER_TIMEOUT, None)
+                    .map_err(|e| anyhow::anyhow!("Failed to create NIP-46 client: {}", e))?;
+
+                // If we have a cached user pubkey, set it to avoid an extra round trip
+                if let Some(cached_pk) = config.cached_user_pubkey() {
+                    let _ = connect.non_secure_set_user_public_key(cached_pk);
+                }
+
+                // Get the user's public key from bunker (or use cached)
+                let public_key = connect
+                    .get_public_key()
+                    .await
+                    .map_err(|e| anyhow::anyhow!(
+                        "Failed to get public key from bunker: {}\n\
+                         \n\
+                         Is the bunker online? Check:\n\
+                         - Bunker process is running\n\
+                         - Relay {} is accessible\n\
+                         - Connection token is still valid",
+                        e,
+                        config.relays.first().unwrap_or(&"(none)".to_string())
+                    ))?;
+
+                eprintln!("✓ Connected to bunker (user: {})", &public_key.to_bech32().unwrap_or_default()[..20]);
+
+                // Update config with successful connection
+                config.update_connected(Some(public_key));
+                config.save(db_path)?;
+
+                {
+                    let mut log = audit.lock().await;
+                    log.record("bunker_connect", &format!("Connected to bunker, user pubkey: {}", public_key.to_hex()));
+                }
+
+                Ok(Self {
+                    mode: SignerMode::Bunker { connect, config },
+                    public_key,
+                    audit,
+                    db_path: db_path.to_path_buf(),
+                })
+            }
+        }
+    }
+
+    /// Get the user's public key
+    pub fn public_key(&self) -> PublicKey {
+        self.public_key
+    }
+
+    /// Get Keys if in direct mode (needed for MDK operations that require Keys)
+    #[allow(dead_code)]
+    pub fn direct_keys(&self) -> Option<&Keys> {
+        match &self.mode {
+            SignerMode::Direct { keys } => Some(keys),
+            SignerMode::Bunker { .. } => None,
+        }
+    }
+
+    /// Check if we're in bunker mode
+    pub fn is_bunker(&self) -> bool {
+        matches!(self.mode, SignerMode::Bunker { .. })
+    }
+
+    /// Get the signing mode description for display
+    pub fn mode_description(&self) -> &str {
+        match &self.mode {
+            SignerMode::Direct { .. } => "direct (nsec)",
+            SignerMode::Bunker { .. } => "NIP-46 bunker",
+        }
+    }
+
+    /// Sign an event using the appropriate method
+    ///
+    /// In direct mode: signs locally
+    /// In bunker mode: sends sign_event request to bunker
+    pub async fn sign_event(&self, builder: EventBuilder) -> Result<Event> {
+        {
+            let mut log = self.audit.lock().await;
+            log.record("sign_event_request", "signing event");
+        }
+
+        let event = match &self.mode {
+            SignerMode::Direct { keys } => {
+                builder.sign(keys).await
+                    .context("Failed to sign event with local keys")?
+            }
+            SignerMode::Bunker { connect, .. } => {
+                let unsigned = builder.build(self.public_key);
+                connect.sign_event(unsigned).await
+                    .map_err(|e| anyhow::anyhow!("Bunker signing failed: {}\nIs the bunker still online?", e))?
+            }
+        };
+
+        {
+            let mut log = self.audit.lock().await;
+            log.record("sign_event_success", &format!("event_id: {}, kind: {}", event.id.to_hex(), event.kind.as_u16()));
+        }
+
+        Ok(event)
+    }
+
+    /// Sign multiple events (batched for efficiency with bunker)
+    ///
+    /// In direct mode: signs all locally (fast)
+    /// In bunker mode: signs sequentially (each requires bunker round-trip)
+    #[allow(dead_code)]
+    pub async fn sign_events(&self, builders: Vec<EventBuilder>) -> Result<Vec<Event>> {
+        let count = builders.len();
+
+        {
+            let mut log = self.audit.lock().await;
+            log.record("sign_batch_request", &format!("count: {}", count));
+        }
+
+        let mut events = Vec::with_capacity(count);
+        for builder in builders {
+            events.push(self.sign_event(builder).await?);
+        }
+
+        {
+            let mut log = self.audit.lock().await;
+            log.record("sign_batch_complete", &format!("count: {}", count));
+        }
+
+        Ok(events)
+    }
+
+    /// Create a gift-wrapped event (used for MLS welcome messages)
+    ///
+    /// This is one of the most critical operations for NIP-46 since gift-wrap
+    /// requires NIP-44 encryption, which the bunker handles remotely.
+    pub async fn gift_wrap(
+        &self,
+        receiver: &PublicKey,
+        rumor: UnsignedEvent,
+    ) -> Result<Event> {
+        {
+            let mut log = self.audit.lock().await;
+            log.record("gift_wrap_request", &format!("receiver: {}", &receiver.to_hex()[..16]));
+        }
+
+        let event = match &self.mode {
+            SignerMode::Direct { keys } => {
+                EventBuilder::gift_wrap(keys, receiver, rumor, [])
+                    .await
+                    .context("Failed to create gift-wrapped event")?
+            }
+            SignerMode::Bunker { connect, .. } => {
+                // Gift-wrap with NIP-46 signer
+                // The nostr crate's gift_wrap function accepts NostrSigner
+                EventBuilder::gift_wrap(connect, receiver, rumor, [])
+                    .await
+                    .map_err(|e| anyhow::anyhow!(
+                        "Bunker gift-wrap failed: {}\n\
+                         Gift wrapping requires NIP-44 encryption via the bunker.",
+                        e
+                    ))?
+            }
+        };
+
+        {
+            let mut log = self.audit.lock().await;
+            log.record("gift_wrap_success", &format!("event_id: {}", event.id.to_hex()));
+        }
+
+        Ok(event)
+    }
+
+    /// Extract a rumor from a gift-wrapped event
+    ///
+    /// In direct mode: decrypts locally
+    /// In bunker mode: uses bunker for NIP-44 decryption
+    pub async fn extract_rumor(&self, event: &Event) -> Result<UnwrappedGift> {
+        match &self.mode {
+            SignerMode::Direct { keys } => {
+                nostr::nips::nip59::extract_rumor(keys, event)
+                    .await
+                    .context("Failed to extract rumor from gift-wrap")
+            }
+            SignerMode::Bunker { connect, .. } => {
+                nostr::nips::nip59::extract_rumor(connect, event)
+                    .await
+                    .map_err(|e| anyhow::anyhow!(
+                        "Bunker gift-unwrap failed: {}\n\
+                         Decrypting gift-wrapped messages requires the bunker to be online.",
+                        e
+                    ))
+            }
+        }
+    }
+
+    /// Build a nostr-sdk Client with the appropriate signer
+    pub async fn build_client(&self) -> Result<Client> {
+        let client = match &self.mode {
+            SignerMode::Direct { keys } => {
+                Client::builder().signer(keys.clone()).build()
+            }
+            SignerMode::Bunker { connect, .. } => {
+                Client::builder().signer(connect.clone()).build()
+            }
+        };
+        Ok(client)
+    }
+
+    /// Shutdown bunker connection (if in bunker mode)
+    #[allow(dead_code)]
+    pub async fn shutdown(self) {
+        if let SignerMode::Bunker { connect, .. } = self.mode {
+            connect.shutdown().await;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements NIP-46 (Nostr Connect) remote signing as an alternative to direct nsec handling. Closes #5.

### Problem

marmot-cli requires direct nsec access, creating security risks for long-running AI agents:
- nsec exposure in process lists and environment variables
- No revocation — compromised keys require full identity rotation
- Persistent key storage in marmot.db

### Solution

Add bunker:// URI support via the `nostr-connect` crate (v0.44), allowing private keys to stay in a secure bunker process while marmot-cli signs events remotely.

## New Features

### Bunker signing mode
```bash
# Initialize with bunker
marmot-cli init --bunker "bunker://<pubkey>?relay=wss://relay.nsec.app&secret=TOKEN"

# Or set via environment
export NOSTR_BUNKER="bunker://..."
marmot-cli whoami  # Shows "signer: NIP-46 bunker"
```

### Atomic migration from nsec to bunker
```bash
# Verifies identity match, preserves MLS group state
marmot-cli migrate-to-bunker --bunker "bunker://..."
```

### Signer status inspection
```bash
marmot-cli signer-status
```

### Audit logging
All signing requests logged to `~/.marmot-cli/marmot.audit.jsonl`

## Architecture

```
marmot-cli  <--NIP-46 via relay-->  Bunker (holds nsec)
(no nsec)     sign_event request    (rate limits, ACL)
              <-- signed event --
```

The `MarmotSigner` abstraction unifies both modes.

## Backward Compatibility

- `--nsec` / `NOSTR_NSEC` works exactly as before
- No changes to MLS/MDK layer
- No changes to message format or relay protocol

## Tests

13 tests, all passing:
- Bunker URI parsing (valid, invalid, multi-relay, no-secret)
- Config persistence (save, load, delete, atomic writes)
- Signing mode resolution (nsec, bunker, stored config, no credentials)
- Audit log (write, disabled mode)

## Addressing feedback from #5

| Concern | Status |
|---------|--------|
| Key package publishing needs bunker online | Clear error if bunker offline |
| Latency for high-freq ops | `sign_events()` batch API; MLS ops are local |
| Audit logging on CLI side | All signing ops logged to .audit.jsonl |
| Atomic migration nsec -> bunker | `migrate-to-bunker` verifies identity match |
